### PR TITLE
Improve layout for tables in .page-content

### DIFF
--- a/radboudumc-theme/sass/_layout.scss
+++ b/radboudumc-theme/sass/_layout.scss
@@ -73,4 +73,21 @@ article {
     max-width: 100%;
     height: auto;
   }
+  
+  // Create better tables for content
+  table {
+    th {
+      border-bottom: solid;
+      border-width: 1px;
+      border-color: black;
+      
+      padding-left: .5em;
+      padding-right: .5em;
+    }
+    
+    td {
+      padding-left: .5em;
+      padding-right: .5em;
+    }    
+  }
 }


### PR DESCRIPTION
Improve layout of dense, hard-to-read tables in current layout for content pages. Currently, tables look like this:

![image](https://user-images.githubusercontent.com/11632379/55942319-6f848c80-5c44-11e9-8817-35c22b3318ec.png)

After merging the same table would look like this:

![image](https://user-images.githubusercontent.com/11632379/55942348-80cd9900-5c44-11e9-8fc5-d6066bd9e0cd.png)

Reference link: https://rse.diagnijmegen.nl/projects/diag-sol/

Note: *I did not test my modifications and am not sure if they will work.*
