### PR TITLE
Improve the quality of optimized images

### DIFF
--- a/imgoptim/optimize.js
+++ b/imgoptim/optimize.js
@@ -70,7 +70,7 @@ function compressImages(paths, targetDir) {
   return imagemin(paths, targetDir, {
     plugins: [
       imageminPngquant(),
-      imageminMozjpeg({quality: 70}),
+      imageminMozjpeg({quality: 100}),
       // imageminWebp({quality: 70}),
       // imageminSvgo({plugins: [{removeViewBox: false}]}),
     ]

--- a/imgoptim/optimize.js
+++ b/imgoptim/optimize.js
@@ -70,7 +70,7 @@ function compressImages(paths, targetDir) {
   return imagemin(paths, targetDir, {
     plugins: [
       imageminPngquant(),
-      imageminMozjpeg({quality: 100}),
+      imageminMozjpeg({quality: 85}),
       // imageminWebp({quality: 70}),
       // imageminSvgo({plugins: [{removeViewBox: false}]}),
     ]

--- a/radboudumc-template/templates/presentations.html
+++ b/radboudumc-template/templates/presentations.html
@@ -14,7 +14,7 @@
         {% for presentation in pages | selectattr('date') | sort(attribute='date', reverse=True) if presentation.parent.url == 'presentations/' %}
           <div class="col-md-4 mb-4">
               <div class="card">
-                  <a href="{{ SITEURL }}/{{ presentation.url }}"><img class="card-img-top lazyload" data-src="{{SITEURL}}/{{ ('images/' + presentation.picture) | resize_image('small') }}" alt="{{ presentation.title }}"></a>
+                  <a href="{{ SITEURL }}/{{ presentation.url }}"><img class="card-img-top lazyload" data-src="{{SITEURL}}/{{ ('images/' + presentation.picture) | resize_image('medium') }}" alt="{{ presentation.title }}"></a>
                   <div class="card-body" style="height: 210px">
                       <h5 class="card-title">{{ presentation.title }}</h5>
                       <p class="text-muted">{{ presentation.author_list }}</p>


### PR DESCRIPTION
As I understand this script is used to optimize the uploaded images to proper dimensions. However, the quality of resized images suffer greatly. See https://beta.diagnijmegen.nl/presentations/. This should fix the issue, however I do not have the whole system running on my local, so I did not test it.