### PR TITLE
added docker files

### DIFF
--- a/docker/.bashrc
+++ b/docker/.bashrc
@@ -1,0 +1,130 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# don't put duplicate lines or lines starting with space in the history.
+# See bash(1) for more options
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# If set, the pattern "**" used in a pathname expansion context will
+# match all files and zero or more directories and subdirectories.
+#shopt -s globstar
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# colored GCC warnings and errors
+#export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi
+
+
+alias python='python3.8'
+#PS1="[\e[92m\\u@\h\e[m:\e[1;34m\\w\e[m]\\$ "
+export PS1="[\[\e[92m\]\u\[\e[m\]\[\e[92m\]@\[\e[m\]\[\e[92m\]\h\[\e[m\]:\[\e[1;34m\]\w\[\e[m\]]\\$ "
+#PS1="\e[1;34m[\\u@\h:\\w]\\$ \e[m"
+PROMPT_DIRTRIM=3
+
+eval "$(dircolors -p | \
+    sed 's/ 4[0-9];/ 01;/; s/;4[0-9];/;01;/g; s/;4[0-9] /;01 /' | \
+    dircolors /dev/stdin)"
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,26 @@
+# This dockerfile configures a base docker image for the computational pathology group.
+#
+FROM doduo1.umcn.nl/uokbaseimage/diag:tf2.5-pt1.9-v1
+
+COPY .bashrc /home/user/.bashrc
+
+COPY requirements.txt ./
+
+RUN sudo apt-get update -y
+RUN sudo apt-get upgrade -y
+RUN sudo apt-get install nodejs -y
+RUN sudo curl -qL https://www.npmjs.com/install.sh | sh
+
+# Prioritize python3
+RUN sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Install website  port.
+#
+EXPOSE 8000
+
+# Copy the entry point script and set the entry point.
+#
+COPY run.sh /root
+ENTRYPOINT ["/bin/bash", "/root/run.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,14 @@
+Automticaly pulls the latest master branch from the website-content repository when starting a new docker instance. An additional argument can be given to automatically build and host a specific website. To do so: provide the name of the directory without the "website-" prefix. 
+
+For instance, to automatically build and run the ai-for-health website:
+./c-submit [put your c-submit arguments here] --interactive doduo1.umcn.nl/webteam/website:latest ai-for-health
+
+Or for the diag website: 
+./c-submit [put your c-submit arguments here] --interactive doduo1.umcn.nl/webteam/website:latest diag
+
+Go to port 8000 (which opens automatically) to view the website on your local machine when running the docker instance. The github repository is located in /home/user/source/website-content.
+
+You can always build and host a specific website manually, by leaving out the additional argument in the c-submit command. 
+
+Detailed example c-submit example command:
+~/c-submit --priority=high --require-mem=4G --gpu-count=0 --require-cpus=1 --node=dlc-ditto --interactive [username] [ticket-number] 4 doduo1.umcn.nl/webteam/website:latest ai-for-health

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,8 @@
+pip==19.3.1
+pelican==4.1.0
+markdown==3.2.2
+latexcodec==1.0.5
+beautifulsoup4==4.7.1
+pyyaml==5.4
+numpy==1.19.4
+requests==2.25.1

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash:
+
+# Cloning website repo
+echo "Cloning website repository."
+echo
+rm -rf /home/user/source/website-content
+git clone https://github.com/DIAGNijmegen/website-content.git /home/user/source/website-content
+chown --recursive user:user /home/user/source/website-content
+chmod 777 /home/user/source/website-content/copy_content.sh
+
+# Check if extra arguments were given and execute it as a command.
+if [ -z "$1" ]
+    then
+        # Print the command for logging.
+        echo "No extra arguments given, running jupyter and sshd"
+        echo
+
+        # Start the SSH daemon and a Jupyter notebook.
+        /usr/sbin/sshd
+        cd /home/user && sudo  --set-home --preserve-env --user=user  /bin/bash -c '/usr/local/bin/jupyter lab --ip=0.0.0.0 --port=8888 --NotebookApp.token='
+
+    else
+        # Print the command for logging.
+        echo "Going to initialize website: ${@}"
+        echo
+        
+        cd /home/user/source/website-content
+        WEBSITE=website-"${@}" sh ./copy_content.sh
+        cd /home/user
+
+        cd /home/user/source/website-content/website-"${@}" && pelican --autoreload --listen &>/dev/null &
+
+        # Start the SSH daemon and a Jupyter notebook.
+        /usr/sbin/sshd
+        cd /home/user && sudo  --set-home --preserve-env --user=user  /bin/bash -c '/usr/local/bin/jupyter lab --ip=0.0.0.0 --port=8888 --NotebookApp.token='
+fi


### PR DESCRIPTION
# What
Docker files required to build a docker which can automatically build and host one of the website. This will make building and changing the website locally easier. The docker is already live, and can be found here: `doduo1.umcn.nl/webteam/website:latest`. It automatically pulls the latest master branch from the website-content repository when starting a new docker instance. An additional argument can be given to automatically build and host a specific website. To do so: provide the name of the directory without the "website-" prefix. 

# Why
Solves GitHub issue #232

# How
For instance, to automatically build and run the ai-for-health website:
./c-submit [put your c-submit arguments here] --interactive doduo1.umcn.nl/webteam/website:latest ai-for-health

Or for the diag website: 
./c-submit [put your c-submit arguments here] --interactive doduo1.umcn.nl/webteam/website:latest diag

Go to port 8000 (which opens automatically) to view the website on your local machine when running the docker instance. The github repository is located in /home/user/source/website-content.

You can always build and host a specific website manually, by leaving out the additional argument in the c-submit command. 

# Example
A more detailed c-submit line, building the ai-for-health website as an example:
` ~/c-submit --priority=high --require-mem=4G --gpu-count=0 --require-cpus=1 --interactive [username] [ticket-number] 4 doduo1.umcn.nl/webteam/website:latest ai-for-health `
