### PR TITLE
Copy only those default pages that are actually used

### DIFF
--- a/copy_content.sh
+++ b/copy_content.sh
@@ -7,7 +7,9 @@ set -e
 python parse_content.py $WEBSITE
 
 # Copy default base pages
-cp -r --no-clobber content/pages/defaults/. $WEBSITE/content/pages/
+cp --no-clobber content/pages/defaults/404.md $WEBSITE/content/pages/404.md
+cp --no-clobber content/pages/defaults/colofon.md $WEBSITE/content/pages/colofon.md
+cp --no-clobber content/pages/defaults/home.md $WEBSITE/content/pages/home.md
 
 # copy bib files
 cp content/bibitems.json $WEBSITE/content/bibitems.json

--- a/parse_content.py
+++ b/parse_content.py
@@ -60,8 +60,9 @@ for dir in directories:
 settings = get_settings_from_file(os.path.join(site, "pelicanconf.py"))
 for section in settings["NAV_SECTIONS"]:
     page = section["url"].split("/")[0] + ".md"
-    file_path = os.path.join("content", "pages", "defaults", page)
-    if os.path.exists(file_path):
-        shutil.copyfile(file_path, os.path.join(site, "content", "pages", page))
+    src_path = os.path.join("content", "pages", "defaults", page)
+    dst_path = os.path.join(site, "content", "pages", page)
+    if os.path.exists(src_path) and not os.path.exists(dst_path):
+        shutil.copyfile(src_path, dst_path)
 
 print(f"Copied pages to {site}.")

--- a/parse_content.py
+++ b/parse_content.py
@@ -53,8 +53,9 @@ for dir in directories:
 # Copy only the default pages that are actually used
 settings = get_settings_from_file(os.path.join(site, 'pelicanconf.py'))
 for section in settings['NAV_SECTIONS']:
-    file_path = os.path.join('content', 'pages', 'defaults', section['url'] + '.md')
+    page = section['url'].split('/')[0] + '.md'
+    file_path = os.path.join('content', 'pages', 'defaults', page)
     if os.path.exists(file_path):
-        shutil.copyfile(file_path, os.path.join(site, 'content', 'pages', section['url'] + '.md'))
+        shutil.copyfile(file_path, os.path.join(site, 'content', 'pages', page))
 
 print(f'Copied pages to {site}.')

--- a/parse_content.py
+++ b/parse_content.py
@@ -3,6 +3,8 @@ import glob
 import shutil
 import sys
 
+from pelican.settings import get_settings_from_file
+
 directories = ['members', 'news', 'presentations', 'projects', 'software', 'vacancies', 'calendar', 'publications', 'research']
 
 site = sys.argv[1]
@@ -48,7 +50,11 @@ for dir in directories:
                 print(f"Error parsing {file_path}.")
                 print(e)
 
-        
-
+# Copy only the default pages that are actually used
+settings = get_settings_from_file(os.path.join(site, 'pelicanconf.py'))
+for section in settings['NAV_SECTIONS']:
+    file_path = os.path.join('content', 'pages', 'defaults', section['url'] + '.md')
+    if os.path.exists(file_path):
+        shutil.copyfile(file_path, os.path.join(site, 'content', 'pages', section['url'] + '.md'))
 
 print(f'Copied pages to {site}.')

--- a/parse_content.py
+++ b/parse_content.py
@@ -5,7 +5,17 @@ import sys
 
 from pelican.settings import get_settings_from_file
 
-directories = ['members', 'news', 'presentations', 'projects', 'software', 'vacancies', 'calendar', 'publications', 'research']
+directories = [
+    "members",
+    "news",
+    "presentations",
+    "projects",
+    "software",
+    "vacancies",
+    "calendar",
+    "publications",
+    "research",
+]
 
 site = sys.argv[1]
 group_name = site[8:]
@@ -18,44 +28,40 @@ for dir in directories:
         os.mkdir(output_dir)
 
 for dir in directories:
-
-    files = glob.glob(os.path.join('content', 'pages', dir, '*.md'))
+    files = glob.glob(os.path.join("content", "pages", dir, "*.md"))
 
     for file_path in files:
         filename = os.path.basename(file_path)
         with open(file_path) as file:
             try:
                 for line in file:
-                    if 'groups:' in line:
+                    if "groups:" in line:
+                        groups = line.split(":")[1].replace(" ", "").rstrip().split(",")
 
-                            groups = line.split(':')[1].replace(' ','').rstrip().split(',')
+                        # Check if the content belongs to the current website
+                        if group_name in groups:
+                            if dir == "news":
+                                # Write hightlights to directory out of pages dir
+                                out_dir = os.path.join(site, "content", dir)
+                            else:
+                                out_dir = os.path.join(site, "content", "pages", dir)
 
-                            # Check if the content belongs to the current website
-                            if group_name in groups:
-                                if dir == 'news':
-                                    # Write hightlights to directory out of pages dir
-                                    out_dir = os.path.join(site, 'content', dir)
-                                else:
-                                    out_dir = os.path.join(site, 'content', 'pages', dir)
+                            if not os.path.exists(out_dir):
+                                os.makedirs(out_dir)
+                            shutil.copyfile(file_path, os.path.join(out_dir, filename))
 
-                                if not os.path.exists(out_dir):
-                                    os.makedirs(out_dir)
-                                shutil.copyfile(file_path, os.path.join(out_dir, filename))
-  
-
-
-                            # Stop parsing file
-                            break
+                        # Stop parsing file
+                        break
             except Exception as e:
                 print(f"Error parsing {file_path}.")
                 print(e)
 
 # Copy only the default pages that are actually used
-settings = get_settings_from_file(os.path.join(site, 'pelicanconf.py'))
-for section in settings['NAV_SECTIONS']:
-    page = section['url'].split('/')[0] + '.md'
-    file_path = os.path.join('content', 'pages', 'defaults', page)
+settings = get_settings_from_file(os.path.join(site, "pelicanconf.py"))
+for section in settings["NAV_SECTIONS"]:
+    page = section["url"].split("/")[0] + ".md"
+    file_path = os.path.join("content", "pages", "defaults", page)
     if os.path.exists(file_path):
-        shutil.copyfile(file_path, os.path.join(site, 'content', 'pages', page))
+        shutil.copyfile(file_path, os.path.join(site, "content", "pages", page))
 
-print(f'Copied pages to {site}.')
+print(f"Copied pages to {site}.")


### PR DESCRIPTION
I've implemented Mart's idea of reading the pelicanconf.py file to find out which pages are actually used. These are now also copied in parse_content.py while copy_content.sh only copies those defaults that are always needed.

Closes #418 